### PR TITLE
Drop Fedora 37 (EOL); add Fedora 39

### DIFF
--- a/os-images/AWS/fedora/fedora-37-arm64.pkrvars.hcl
+++ b/os-images/AWS/fedora/fedora-37-arm64.pkrvars.hcl
@@ -1,2 +1,0 @@
-ami_filter    = "Fedora-Cloud-Base-37-*.aarch64-hvm-*-gp2-0"
-instance_type = "m6g.large"

--- a/os-images/AWS/fedora/fedora-37-x86_64.pkrvars.hcl
+++ b/os-images/AWS/fedora/fedora-37-x86_64.pkrvars.hcl
@@ -1,2 +1,0 @@
-ami_filter    = "Fedora-Cloud-Base-37-*.x86_64-hvm-*-gp2-0"
-instance_type = "t3a.large"

--- a/os-images/AWS/fedora/fedora-39-arm64.pkrvars.hcl
+++ b/os-images/AWS/fedora/fedora-39-arm64.pkrvars.hcl
@@ -1,0 +1,2 @@
+ami_filter    = "Fedora-Cloud-Base-39-*.aarch64-hvm-*-gp2-0"
+instance_type = "m6g.large"

--- a/os-images/AWS/fedora/fedora-39-x86_64.pkrvars.hcl
+++ b/os-images/AWS/fedora/fedora-39-x86_64.pkrvars.hcl
@@ -1,0 +1,2 @@
+ami_filter    = "Fedora-Cloud-Base-39-*.x86_64-hvm-*-gp2-0"
+instance_type = "t3a.large"


### PR DESCRIPTION
- Fedora 37 is EOL, so dropping
- Fedora 39 is now GA