### PR TITLE
Upgrade to latest Salt 3006.x for all provisioning

### DIFF
--- a/golden-state-tree/os/windows/pkgs/python3.sls
+++ b/golden-state-tree/os/windows/pkgs/python3.sls
@@ -1,7 +1,7 @@
-{%- set python3_dir = 'c:\\\\Python38' %}
+{%- set python3_dir = 'c:\\\\Python310' %}
 
 python3:
   pkg.installed:
     - name: python3_x64
-    - version: '3.8.10150.0'
+    - version: '3.10.4150.0'
     - extra_install_flags: "TargetDir={{ python3_dir }} Include_doc=0 Include_tcltk=0 Include_test=0 Include_launcher=1 PrependPath=1 Shortcuts=0"

--- a/golden-state-tree/python-pkgs/pyyaml.sls
+++ b/golden-state-tree/python-pkgs/pyyaml.sls
@@ -8,7 +8,7 @@
 
 pyyaml:
   cmd.run:
-    - name: {{ pip }} install pyyaml==5.4.1
+    - name: {{ pip }} install pyyaml==6.0.1
     - unless:
       {%- if grains['os_family'] == 'Windows' %}
       - py -3 -c "import yaml"

--- a/os-images/AWS/almalinux/almalinux.pkr.hcl
+++ b/os-images/AWS/almalinux/almalinux.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3005.1+2103.gc1fc63d39a"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/AWS/amazonlinux/amazonlinux.pkr.hcl
+++ b/os-images/AWS/amazonlinux/amazonlinux.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3005.1+2103.gc1fc63d39a"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/AWS/amazonlinux2000/amazonlinux2000.pkr.hcl
+++ b/os-images/AWS/amazonlinux2000/amazonlinux2000.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3006.2"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/AWS/archlinux/archlinux.pkr.hcl
+++ b/os-images/AWS/archlinux/archlinux.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3006.2"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/AWS/centos/centos.pkr.hcl
+++ b/os-images/AWS/centos/centos.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3006.0"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/AWS/debian/debian.pkr.hcl
+++ b/os-images/AWS/debian/debian.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3006.0"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/AWS/fedora/fedora.pkr.hcl
+++ b/os-images/AWS/fedora/fedora.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3006.0"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/AWS/opensuse/opensuse.pkr.hcl
+++ b/os-images/AWS/opensuse/opensuse.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3006.0"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/AWS/photon/photon.pkr.hcl
+++ b/os-images/AWS/photon/photon.pkr.hcl
@@ -68,7 +68,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3006.0"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {
@@ -184,7 +184,7 @@ build {
     inline = [
       "systemctl mask tmp.mount",
       "find /etc/yum.repos.d -type f -exec sed -i 's!dl.bintray.com/vmware!packages.vmware.com/photon/$releasever!' {} ';'",
-      "tdnf update -y",
+      "if [ ${var.distro_version} == '4' ]; then tdnf update -y photon-repos-4.0-3.ph4 --enablerepo=photon --refresh ; else tdnf update -y; fi",
     ]
     inline_shebang = "/bin/sh -ex"
   }

--- a/os-images/AWS/rockylinux/rockylinux.pkr.hcl
+++ b/os-images/AWS/rockylinux/rockylinux.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3006.0"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/AWS/ubuntu/ubuntu.pkr.hcl
+++ b/os-images/AWS/ubuntu/ubuntu.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3006.0"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/AWS/windows/scripts/Provision-Salt.ps1
+++ b/os-images/AWS/windows/scripts/Provision-Salt.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = "Stop"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $SALT_ARCHIVE_NAME="salt-$Env:SALT_VERSION-onedir-windows-$Env:OS_ARCH.zip"
-$SALT_DOWNLOAD_URL="http://salt-onedir-golden-images-provision.s3-website-us-west-2.amazonaws.com/$SALT_ARCHIVE_NAME"
+$SALT_DOWNLOAD_URL="https://repo.saltproject.io/salt/py3/onedir/minor/$Env:SALT_VERSION/$SALT_ARCHIVE_NAME"
 $DST = "$Env:TEMP\$SALT_ARCHIVE_NAME"
 Write-Host "`nDownloading $SALT_DOWNLOAD_URL ..." -ForegroundColor Yellow
 $wc = New-Object System.Net.WebClient

--- a/os-images/AWS/windows/windows.pkr.hcl
+++ b/os-images/AWS/windows/windows.pkr.hcl
@@ -66,7 +66,7 @@ variable "salt_provision_type" {
 
 variable "salt_provision_version" {
   type    = string
-  default = "3006.0"
+  default = "3006.8"
 }
 
 variable "salt_provision_root_dir" {

--- a/os-images/files/provision-salt.sh
+++ b/os-images/files/provision-salt.sh
@@ -11,8 +11,15 @@ else
     PLATFORM="macos"
 fi
 
-SALT_ARCHIVE_NAME="salt-${SALT_VERSION}-onedir-${PLATFORM}-${OS_ARCH}.tar.xz"
-SALT_DOWNLOAD_URL="http://salt-onedir-golden-images-provision.s3-website-us-west-2.amazonaws.com/${SALT_ARCHIVE_NAME}"
+if [ "${OS_ARCH}" = "aarch64" ]; then
+    SALT_ARCH="arm64"
+else
+    SALT_ARCH="${OS_ARCH}"
+fi
+
+# SALT_MAJOR_VERSION=$(echo "${SALT_VERSION}" | cut -f1 -d'.')
+SALT_ARCHIVE_NAME="salt-${SALT_VERSION}-onedir-${PLATFORM}-${SALT_ARCH}.tar.xz"
+SALT_DOWNLOAD_URL="https://repo.saltproject.io/salt/py3/onedir/minor/${SALT_VERSION}/${SALT_ARCHIVE_NAME}"
 
 if [ "$(which curl)x" != "x" ]; then
     curl -f --output /tmp/${SALT_ARCHIVE_NAME} ${SALT_DOWNLOAD_URL}


### PR DESCRIPTION
- Upgrade to latest Salt v3006.x for all Salt provisioning
  - Included upgrading the salt provisioning scripts to point to the official repo download location of onedir archives
  - Went with Salt v3006.8 due to Windows-related bug(s) being fixed
- Upgrades base Python 3.8.x to Python 3.10.x on Windows operating systems
  - Required an upgrade to `pyyaml` to avoid `cython` attribute errors
- Fix Photon OS 4 errors caused by GPG key expirations