### PR TITLE
Add Fedora 40 and Ubuntu 24.04

### DIFF
--- a/golden-state-tree/os/fedora/pkgs/init.sls
+++ b/golden-state-tree/os/fedora/pkgs/init.sls
@@ -29,8 +29,8 @@ include:
   - pkgs.swig
   - pkgs.tar
   - pkgs.zlib
-  {%- if os_major_release != 38 %}
-  {#- There's no vault packages for Fedora 38 yet as it's the unstable version of Fedora #}
+  {%- if os_major_release <= 39 %}
+  {#- Newer OS targets don't require vault for CI/CD, as community salt extensions cover this #}
   - pkgs.vault
   {%- endif %}
   - pkgs.jq

--- a/golden-state-tree/os/ubuntu/pkgs/init.sls
+++ b/golden-state-tree/os/ubuntu/pkgs/init.sls
@@ -33,7 +33,8 @@ include:
   - pkgs.swig
   - pkgs.tar
   - pkgs.zlib
-  {%- if grains['osmajorrelease'] != 23 %}
+  {%- if grains['osmajorrelease'] <= 22 %}
+  {#- Newer OS targets don't require vault for CI/CD, as community salt extensions cover this #}
   - pkgs.vault
   {%- endif %}
   - pkgs.jq

--- a/golden-state-tree/pkgs/zlib.sls
+++ b/golden-state-tree/pkgs/zlib.sls
@@ -9,6 +9,9 @@ zlib:
 {%- elif grains['os_family'] == "Suse" %}
       - libz1
       - zlib-devel
+{%- elif grains['os'] == "Fedora" %}
+      - zlib-ng-compat
+      - zlib-ng-compat-devel
 {%- else %}
       - zlib
       - zlib-devel

--- a/os-images/AWS/debian/debian-10-arm64.pkrvars.hcl
+++ b/os-images/AWS/debian/debian-10-arm64.pkrvars.hcl
@@ -1,3 +1,0 @@
-ami_filter    = "debian-10-arm64-20*"
-ami_owner     = "136693071363"
-instance_type = "m6g.large"

--- a/os-images/AWS/debian/debian-10-x86_64.pkrvars.hcl
+++ b/os-images/AWS/debian/debian-10-x86_64.pkrvars.hcl
@@ -1,3 +1,0 @@
-ami_filter    = "debian-10-amd64-20*"
-ami_owner     = "136693071363"
-instance_type = "t3a.large"

--- a/os-images/AWS/fedora/fedora-39-arm64.pkrvars.hcl
+++ b/os-images/AWS/fedora/fedora-39-arm64.pkrvars.hcl
@@ -1,2 +1,0 @@
-ami_filter    = "Fedora-Cloud-Base-39-*.aarch64-hvm-*-gp3-0"
-instance_type = "m6g.large"

--- a/os-images/AWS/fedora/fedora-39-x86_64.pkrvars.hcl
+++ b/os-images/AWS/fedora/fedora-39-x86_64.pkrvars.hcl
@@ -1,2 +1,0 @@
-ami_filter    = "Fedora-Cloud-Base-39-*.x86_64-hvm-*-gp3-0"
-instance_type = "t3a.large"

--- a/os-images/AWS/fedora/fedora-40-arm64.pkrvars.hcl
+++ b/os-images/AWS/fedora/fedora-40-arm64.pkrvars.hcl
@@ -1,0 +1,2 @@
+ami_filter    = "Fedora-Cloud-Base-AmazonEC2.aarch64-40-*-hvm-*-gp3-0"
+instance_type = "m6g.large"

--- a/os-images/AWS/fedora/fedora-40-x86_64.pkrvars.hcl
+++ b/os-images/AWS/fedora/fedora-40-x86_64.pkrvars.hcl
@@ -1,0 +1,2 @@
+ami_filter    = "Fedora-Cloud-Base-AmazonEC2.x86_64-40-*-hvm-*-gp3-0"
+instance_type = "t3a.large"

--- a/os-images/AWS/ubuntu/ubuntu-23.04-arm64.pkrvars.hcl
+++ b/os-images/AWS/ubuntu/ubuntu-23.04-arm64.pkrvars.hcl
@@ -1,3 +1,0 @@
-ami_filter    = "ubuntu/images/hvm-ssd/ubuntu-lunar-23.04-arm64-server-*"
-instance_type = "m6g.large"
-ami_owner     = "099720109477"

--- a/os-images/AWS/ubuntu/ubuntu-23.04-x86_64.pkrvars.hcl
+++ b/os-images/AWS/ubuntu/ubuntu-23.04-x86_64.pkrvars.hcl
@@ -1,3 +1,0 @@
-ami_filter    = "ubuntu/images/hvm-ssd/ubuntu-lunar-23.04-amd64-server-*"
-instance_type = "t3a.large"
-ami_owner     = "099720109477"

--- a/os-images/AWS/ubuntu/ubuntu-24.04-arm64.pkrvars.hcl
+++ b/os-images/AWS/ubuntu/ubuntu-24.04-arm64.pkrvars.hcl
@@ -1,0 +1,3 @@
+ami_filter    = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"
+instance_type = "m6g.large"
+ami_owner     = "099720109477"

--- a/os-images/AWS/ubuntu/ubuntu-24.04-x86_64.pkrvars.hcl
+++ b/os-images/AWS/ubuntu/ubuntu-24.04-x86_64.pkrvars.hcl
@@ -1,0 +1,3 @@
+ami_filter    = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
+instance_type = "t3a.large"
+ami_owner     = "099720109477"


### PR DESCRIPTION
- Fedora 40 released this week, so prepping new AMIs
  - Required for https://github.com/saltstack/salt/issues/66300 
- Ubuntu 24.04 released this week, so prepping new AMIs
  - Required for https://github.com/saltstack/salt/issues/66180
- Salt Project only supports the very latest Fedora release, so dropping Fedora 39
- Newer operating systems are not going to have `vault` installed, as it is slowly being phased out in favor of the community salt extension: https://github.com/salt-extensions/saltext-vault
- Dropping Debian 10
  - Related to: https://github.com/saltstack/salt/pull/66412