### PR TITLE
feat(ubuntu): Install brew package manager on x86_64

### DIFF
--- a/os-images/AWS/ubuntu/scripts/install_brew.sh
+++ b/os-images/AWS/ubuntu/scripts/install_brew.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ "$(uname -m)" != 'x86_64' ]]; then
+  echo "brew won't be installed for $(uname -m) architecture"
+  exit 0
+fi
+
+echo "====> Installing homebrew"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/os-images/AWS/ubuntu/scripts/install_brew.sh
+++ b/os-images/AWS/ubuntu/scripts/install_brew.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Exit on failures
+set -e
+# Echo what runs
+set -x
+
 if [[ "$(uname -m)" != 'x86_64' ]]; then
   echo "brew won't be installed for $(uname -m) architecture"
   exit 0

--- a/os-images/AWS/ubuntu/ubuntu.pkr.hcl
+++ b/os-images/AWS/ubuntu/ubuntu.pkr.hcl
@@ -207,7 +207,7 @@ build {
 
   provisioner "shell" {
     inline_shebang  = "/bin/bash -ex"
-    execute_command = "sudo -E -H bash -c '{{ .Vars }} {{ .Path }}'"
+    execute_command = "sudo -E -H -u ${var.ssh_username} bash -c '{{ .Vars }} {{ .Path }}'"
     script          = "${path.root}/scripts/install_brew.sh"
   }
 

--- a/os-images/AWS/ubuntu/ubuntu.pkr.hcl
+++ b/os-images/AWS/ubuntu/ubuntu.pkr.hcl
@@ -206,6 +206,12 @@ build {
   }
 
   provisioner "shell" {
+    inline_shebang  = "/bin/bash -ex"
+    execute_command = "sudo -E -H bash -c '{{ .Vars }} {{ .Path }}'"
+    script          = "${path.root}/scripts/install_brew.sh"
+  }
+
+  provisioner "shell" {
     execute_command = "sudo -E -H bash -c '{{ .Vars }} {{ .Path }}'"
     inline = [
       "curl -f https://s3.amazonaws.com/amazoncloudwatch-agent/assets/amazon-cloudwatch-agent.gpg -o /tmp/amazon-cloudwatch-agent.gpg",


### PR DESCRIPTION
Add [Homebrew](https://brew.sh) package manager to Ubuntu (x86_64) machines.

This package is needed to allow brew testability on Linux machines after having extended the [`mac_brew_pkg.py`](https://github.com/saltstack/salt/blob/ac6aae4fae845accf8c64301ac431037c1a6d4fe/salt/modules/mac_brew_pkg.py) module to allow Linux in https://github.com/saltstack/salt/pull/66609